### PR TITLE
3x speed up

### DIFF
--- a/xml2json/speed_test.py
+++ b/xml2json/speed_test.py
@@ -13,7 +13,7 @@ BASEPATH: str = os.path.dirname(os.path.abspath(__file__))
 
 xml_dir: str = os.path.join(BASEPATH, "..", "fixtures", "xml")
 json_dir: str = "/tmp/xml2json"
-os.makedirs(json_dir)
+os.makedirs(json_dir, exist_ok=True)
 
 translate: JsonTranslator = JsonTranslator()
 

--- a/xml2json/xmlio.py
+++ b/xml2json/xmlio.py
@@ -8,10 +8,16 @@ import lxml.etree
 from lxml import etree
 from lxml.etree import XMLParser, parse
 from xmljson import XMLData
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 
 # noinspection PyProtectedMember
-from xml2json.convert import convert
+# from .convert import convert
+
+import sys
+# Python 3: define unicode() as str()
+if sys.version_info[0] == 3:
+    unicode = str
+    basestring = str
 
 Element = lxml.etree._Element
 
@@ -66,14 +72,46 @@ def _get_cleaned_root(raw_xml: str) -> Element:
 class MongoFish(XMLData):
     """Same as BadgerFish convention, except changes "$" to "_" for Mongo."""
     def __init__(self, **kwargs):
-        super(MongoFish, self).__init__(attr_prefix='@', text_content='_', **kwargs)
+        super(MongoFish, self).__init__(
+            dict_type=OrderedDict, xml_fromstring=False, text_content=True, simple_text=True)
 
+    def data(self, root):
+        '''Convert etree.Element into a dictionary'''
+        value = self.dict()
+        children = [node for node in root if isinstance(node.tag, basestring)]
+        
+        root_d = self.dict()
+        for attr, attrval in root.attrib.items():
+            root_d[root.tag + '@' + attr] = self._fromstring(attrval)
+        if root.text and self.text_content is not None:
+            text = root.text.strip()
+            if text:
+                if self.simple_text and len(children) == 0:
+                    value = self._fromstring(text)
+                else:
+                    value[self.text_content] = self._fromstring(text)
+        count = Counter(child.tag for child in children)
+        for child in children:
+            if count[child.tag] == 1:
+                value.update(self.data(child))
+            else:
+                result = value.setdefault(child.tag, self.list())
+                result += self.data(child).values()
+                
+        # if simple_text, elements with no children nor attrs become empty dict not {}
+        if isinstance(value, dict) and not value and self.simple_text:
+            return self.dict() #  value = ''
+
+        root_d[root.tag] = value
+        root_d.move_to_end(root.tag, last=False)
+        return root_d #  self.dict([(root.tag, value)])
 
 class JsonTranslator(Callable):
     def __init__(self):
-        self._fish = MongoFish(dict_type=OrderedDict, xml_fromstring=False)
+        self._fish = MongoFish()
 
     def __call__(self, xml_str: str):
         xml = _get_cleaned_root(xml_str)
         fish_json = self._fish.data(xml)
-        return convert(fish_json)
+
+        return fish_json #  convert(fish_json)


### PR DESCRIPTION
I've noticed the job is already closed. But you can freely reuse the code, as it's already done. 
On my pc it runs 3x fast, and no need to convert at all.

There is a bug in your converter (that works correct with my code). Like in 729/201143199349202614_public.xml the lines:
      <StatesWhereCopyOfReturnIsFiled>MA</StatesWhereCopyOfReturnIsFiled>
      <StatesWhereCopyOfReturnIsFiled>NY</StatesWhereCopyOfReturnIsFiled>
      <StatesWhereCopyOfReturnIsFiled>VT</StatesWhereCopyOfReturnIsFiled>
      <StatesWhereCopyOfReturnIsFiled>NH</StatesWhereCopyOfReturnIsFiled>
      <StatesWhereCopyOfReturnIsFiled>ME</StatesWhereCopyOfReturnIsFiled>
      <StatesWhereCopyOfReturnIsFiled>CT</StatesWhereCopyOfReturnIsFiled>

Should be converted to 
StatesWhereCopyOfReturnIsFiled: ['MA' ...]
In your fixtures, you get
"StatesWhereCopyOfReturnIsFiled": [{}, {}, {}, {}, {}, {}],


